### PR TITLE
feat(package): add test cases API

### DIFF
--- a/examples/lib/main.py
+++ b/examples/lib/main.py
@@ -1,34 +1,23 @@
 """
 Example of using BLINKG programmatically to evaluate predictions.
 """
-from blinkg import evaluate
-from rdflib import Graph
-import pandas as pd
+from blinkg import evaluate, load_test_case, list_test_cases
 
-# Example: Load ground truth
-ground_truth = pd.DataFrame({
-    "CSV Column": ["id", "name", "age"],
-    "Ontology Property": ["schema:identifier", "schema:name", "schema:age"],
-    "Entity Class": ["schema:Person", "schema:Person", "schema:Person"],
-})
+# List available test cases
+test_case_ids = list_test_cases()
+print("Available test cases:", test_case_ids)
 
-# Example: Your predictions
-# This would come from your mapping tool output
-predictions = pd.DataFrame({
-    "CSV Column": ["id", "name", "age"],
-    "Ontology Property": ["schema:identifier", "schema:name", "schema:age"],
-    "Entity Class": ["schema:Person", "schema:Person", "schema:Person"],
-})
+# Load a benchmark test case
+test_case = load_test_case(test_case_ids[0])
+print(f"\nLoaded: {test_case.description}")
+print(f"Input files: {list(test_case.input_data.keys())}")
 
-# Load ontology
-ontology = Graph()
-# ontology.parse("path/to/your/ontology.ttl", format="turtle")
-# For this example, we'll use an empty graph
-ontology.parse(data="@prefix schema: <http://schema.org/> .", format="turtle")
+# Your predictions (for this example, we use ground truth for perfect score)
+predictions = test_case.ground_truth.copy()
 
 # Evaluate predictions against ground truth
 print("Running BLINKG evaluation...")
-metrics = evaluate(predictions, ground_truth, ontology, threshold=0.8)
+metrics = evaluate(predictions, test_case.ground_truth, test_case.ontology, threshold=0.8)
 
 # Display results
 print("\n=== Evaluation Results ===")
@@ -38,5 +27,3 @@ for col, m in metrics.items():
     print(f"  Recall:    {m['recall']:.3f}")
     print(f"  F1:        {m['f1']:.3f}")
     print(f"  TP: {m['TP']}, FP: {m['FP']}, FN: {m['FN']}")
-
-print("\nEvaluation complete!")

--- a/src/blinkg/__init__.py
+++ b/src/blinkg/__init__.py
@@ -1,30 +1,6 @@
 """BLINKG: Benchmark for LLM-Integrated Knowledge Graph Generation"""
 
-from .evaluate import match_tables, calculate_prf
-from rdflib import Graph
-import pandas as pd
+from .evaluate import evaluate
+from .test_case import TestCase, list_test_cases, load_test_case
 
 __version__ = "0.1.0"
-
-
-def evaluate(predictions: pd.DataFrame,
-             ground_truth: pd.DataFrame,
-             ontology: Graph,
-             threshold: float = 0.8):
-    """
-    Evaluate predictions against ground truth.
-
-    Args:
-        predictions: DataFrame with predicted mappings
-        ground_truth: DataFrame with expected mappings
-        ontology: RDFLib Graph with the ontology
-        threshold: Similarity threshold for TP/FP/FN (default: 0.8)
-
-    Returns:
-        dict: Metrics per column with format:
-            {column_name: {'TP': int, 'FP': int, 'FN': int,
-                          'precision': float, 'recall': float, 'f1': float}}
-    """
-    pairs, common_cols, _ = match_tables(predictions, ground_truth)
-    metrics = calculate_prf(predictions, ground_truth, pairs, common_cols, ontology, threshold)
-    return metrics

--- a/src/blinkg/evaluate.py
+++ b/src/blinkg/evaluate.py
@@ -1,9 +1,18 @@
 import Levenshtein
-from .utils import *
 import numpy as np
+import pandas as pd
 from sentence_transformers import util
 from rdflib import Graph
 import re
+
+from .utils import (
+    empty_values,
+    model,
+    get_property_lexicalization,
+    strip_shared_prefixes,
+    expand_to_full_uri,
+    clean_values
+)
 
 # Patterns to detect canonical fields regardless of exact header text
 _field_patterns = {
@@ -270,3 +279,26 @@ def calculate_prf(t1: pd.DataFrame,
         agg[col]['f1'] = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
 
     return agg
+
+
+def evaluate(predictions: pd.DataFrame,
+             ground_truth: pd.DataFrame,
+             ontology: Graph,
+             threshold: float = 0.8):
+    """
+    Evaluate predictions against ground truth.
+
+    Args:
+        predictions: DataFrame with predicted mappings
+        ground_truth: DataFrame with expected mappings
+        ontology: RDFLib Graph with the ontology
+        threshold: Similarity threshold for TP/FP/FN (default: 0.8)
+
+    Returns:
+        dict: Metrics per column with format:
+            {column_name: {'TP': int, 'FP': int, 'FN': int,
+                          'precision': float, 'recall': float, 'f1': float}}
+    """
+    pairs, common_cols, _ = match_tables(predictions, ground_truth)
+    metrics = calculate_prf(predictions, ground_truth, pairs, common_cols, ontology, threshold)
+    return metrics

--- a/src/blinkg/test_case.py
+++ b/src/blinkg/test_case.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import List, Dict
+import pandas as pd
+from rdflib import Graph
+
+
+@dataclass
+class TestCase:
+    """
+    Benchmark test case for evaluating KG mapping approaches.
+
+    Attributes:
+        id: Unique identifier (e.g., 'scenario1_1A')
+        description: Human-readable description
+        input_data: Source data as DataFrames (filename -> DataFrame)
+        ontology: Target ontology (RDF Graph, includes SKOS)
+        ground_truth: Expected mappings (DataFrame)
+    """
+    id: str
+    description: str
+    input_data: Dict[str, pd.DataFrame]
+    ontology: Graph
+    ground_truth: pd.DataFrame
+
+
+def list_test_cases() -> List[str]:
+    from .test_cases._loader import list_all_test_cases
+    return list_all_test_cases()
+
+
+def load_test_case(test_case_id: str) -> TestCase:
+    from .test_cases._loader import load_test_case_from_disk
+    return load_test_case_from_disk(test_case_id)

--- a/src/blinkg/test_cases/_loader.py
+++ b/src/blinkg/test_cases/_loader.py
@@ -1,0 +1,89 @@
+from typing import List
+import re
+from ..test_case import TestCase
+from ._utils import (
+    get_scenarios_base,
+    load_csv_inputs,
+    load_ontology,
+    load_skos,
+    load_ground_truth,
+    list_test_cases_in
+)
+
+
+SCENARIO_REGISTRY = {
+    'scenario1': {
+        'description': 'Schema-Aligned Mapping',
+        'ontology': 'ontology.ttl',
+        'skos': None,
+    },
+    'scenario2': {
+        'description': 'GTFS Functional Mapping',
+        'ontology': 'ontology_{test_case}.ttl',
+        'skos': 'skos_{test_case}.ttl',
+    },
+    'scenario3': {
+        'description': 'Schema-Distant High Abstraction',
+        'ontology': 'ontology.ttl',
+        'skos': 'skos.ttl',
+    },
+}
+
+
+def list_all_test_cases() -> List[str]:
+    scenarios_base = get_scenarios_base()
+    test_case_ids = []
+
+    for scenario_name in SCENARIO_REGISTRY.keys():
+        scenario_path = scenarios_base / scenario_name
+        try:
+            test_cases = list_test_cases_in(scenario_path)
+            for test_case in test_cases:
+                test_case_ids.append(f"{scenario_name}_{test_case}")
+        except FileNotFoundError:
+            continue
+
+    return test_case_ids
+
+
+def load_test_case_from_disk(test_case_id: str) -> TestCase:
+    match = re.match(r'(scenario\d+)_(.+)', test_case_id)
+    if not match:
+        raise ValueError(
+            f"Invalid test case ID format: '{test_case_id}'. "
+            f"Expected format: 'scenario1_1A', 'scenario2_d1', etc."
+        )
+
+    scenario_name = match.group(1)
+    test_case = match.group(2)
+
+    if scenario_name not in SCENARIO_REGISTRY:
+        raise ValueError(f"Unknown scenario: '{scenario_name}'")
+
+    config = SCENARIO_REGISTRY[scenario_name]
+    scenarios_dir = get_scenarios_base()
+    test_dir = scenarios_dir / scenario_name / test_case
+
+    if not test_dir.exists():
+        raise FileNotFoundError(f"Test case '{test_case_id}' not found at {test_dir}")
+
+    input_data = load_csv_inputs(test_dir)
+
+    ontology_file = config['ontology'].format(test_case=test_case)
+    ontology = load_ontology(test_dir, ontology_file)
+
+    if config['skos']:
+        skos_file = config['skos'].format(test_case=test_case)
+        load_skos(ontology, test_dir, skos_file)
+
+    ground_truth = load_ground_truth(test_dir)
+
+    description = f"Scenario {scenario_name[-1]}: {config['description']} - Test Case {test_case}"
+
+    return TestCase(
+        id=test_case_id,
+        description=description,
+        input_data=input_data,
+        ontology=ontology,
+        ground_truth=ground_truth
+    )

--- a/src/blinkg/test_cases/_utils.py
+++ b/src/blinkg/test_cases/_utils.py
@@ -1,0 +1,78 @@
+from typing import Dict, List
+import pandas as pd
+from pathlib import Path
+from rdflib import Graph
+
+
+def parse_md_table(md_text: str) -> pd.DataFrame:
+    lines = [line.strip() for line in md_text.strip().split('\n') if line.strip()]
+
+    if len(lines) < 2:
+        raise ValueError("Markdown table must have at least header and separator rows")
+
+    headers = [h.strip() for h in lines[0].split('|') if h.strip()]
+
+    data = []
+    for line in lines[2:]:
+        row = [cell.strip() for cell in line.split('|') if cell.strip()]
+        if len(row) == len(headers):
+            data.append(row)
+
+    return pd.DataFrame(data, columns=headers)
+
+
+def get_scenarios_base() -> Path:
+    module_dir = Path(__file__).parent
+    repo_root = module_dir.parent.parent.parent
+    scenarios_dir = repo_root / "scenarios"
+
+    if not scenarios_dir.exists():
+        raise FileNotFoundError(f"Scenarios directory not found at {scenarios_dir}")
+
+    return scenarios_dir
+
+
+def load_csv_inputs(test_dir: Path) -> Dict[str, pd.DataFrame]:
+    input_data = {}
+    for csv_file in test_dir.glob("*.csv"):
+        input_data[csv_file.name] = pd.read_csv(csv_file)
+    return input_data
+
+
+def load_ontology(test_dir: Path, filename: str) -> Graph:
+    ontology = Graph()
+    ontology_file = test_dir / filename
+
+    if not ontology_file.exists():
+        raise FileNotFoundError(f"Ontology file not found: {ontology_file}")
+
+    ontology.parse(ontology_file, format="turtle")
+    return ontology
+
+
+def load_skos(ontology: Graph, test_dir: Path, filename: str) -> None:
+    """Merge SKOS file into ontology graph if present."""
+    skos_file = test_dir / filename
+    if skos_file.exists():
+        ontology.parse(skos_file, format="turtle")
+
+
+def load_ground_truth(test_dir: Path) -> pd.DataFrame:
+    expected_table = test_dir / "expected_table.md"
+
+    if not expected_table.exists():
+        raise FileNotFoundError(f"Ground truth not found: {expected_table}")
+
+    return parse_md_table(expected_table.read_text(encoding='utf-8'))
+
+
+def list_test_cases_in(scenario_dir: Path) -> List[str]:
+    if not scenario_dir.exists():
+        raise FileNotFoundError(f"Scenario directory not found at {scenario_dir}")
+
+    test_cases = []
+    for subdir in sorted(scenario_dir.iterdir()):
+        if subdir.is_dir() and (subdir / "expected_table.md").exists():
+            test_cases.append(subdir.name)
+
+    return test_cases


### PR DESCRIPTION
## Description

This PR extends BLINKG with a simple API for loading benchmark test cases programmatically. The new functions allow users to:
- Load individual test cases with their input data, ontology, and ground truth
- List all available test cases

so they can use their tools to make predictions and then evaluate their performance.

## Usage
 
See examples/lib/main.py for a complete working example.
 
 ---
 
 Please, feel free to modify the PR as required.