### PR TITLE
docs: add using blinkg as a lib to the examples README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It's mandatory to introduce at least one input data file and the ontology file. 
 
 Adding a new scenario to the benchmark is also supported: contributors can open a GitHub issue using the dedicated _Add new BLINKG scenario_ template (```scenario_request```), where they specify the target ontology, input data, and gold-standard format so that the new scenario can be integrated consistently into BLINKG. 
 
-## How can I use BLINKG as a library
+## How can I use BLINKG as a library?
 
 You can use BLINKG as a library in your own code. After installing with:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# Usage examples
+
+## Programmatic usage (lib)
+
+This section demonstrates how to use BLINKG as a library for evaluating knowledge graph mappings programmatically.
+
+The example illustrates the core evaluation workflow:
+1. Listing available test cases from the benchmark scenarios
+2. Loading a specific test case with its input data, ground truth, and ontology
+3. Evaluating predicted mappings against gold-standard references using the `evaluate()` function
+4. Analyzing results with detailed metrics including precision, recall, F1 scores, and confusion matrix values


### PR DESCRIPTION
## Description

This PR creates a `README.md` file at the `examples/` level and briefly describes the `lib` example.

---

Please feel free to change the PR as needed.